### PR TITLE
Finalmente se ve mejor en iPad

### DIFF
--- a/src/front/styles/Game.css
+++ b/src/front/styles/Game.css
@@ -372,6 +372,12 @@
 
 /* ----- // MEDIA QUERIES (HEIGHT) // ----- */
 
+@media screen and (min-height: 800px) {
+    .marco-menu-game {
+        display: none;
+    }
+}
+
 @media screen and (min-height: 920px) {
     .marco-menu-game {
         display: none;

--- a/src/front/styles/Home.css
+++ b/src/front/styles/Home.css
@@ -20,7 +20,7 @@
   position: absolute;
   top: 3%;
   opacity: 80%;
-  left: 1%;
+  left: .5%;
   z-index: -1;
 }
 

--- a/src/front/styles/Menu.css
+++ b/src/front/styles/Menu.css
@@ -278,6 +278,12 @@
 
 /* ----- // MEDIA QUERIES (HEIGHT) // ----- */
 
+@media screen and (min-height: 800px) {
+    .marco-menu {
+        display: none;
+    }
+}
+
 @media screen and (min-height: 920px) {
     .menu-opened {
         height: 100%;


### PR DESCRIPTION
Arreglos para dispositivos con más de 800px de alto.

- Quitando marco de menú y Game.jsx
- Corrigiendo left de marco en Home.jsx (No calculé la barra de tareas de iPad y se rompía lo visual del hero).